### PR TITLE
Remove usage of undefined `lists:join/3` function

### DIFF
--- a/src/k_io_lib_pretty.erl
+++ b/src/k_io_lib_pretty.erl
@@ -394,9 +394,7 @@ print_length(Tuple, D, RF, Enc, Str) when is_tuple(Tuple) ->
 print_length(<<>>, _D, _RF, _Enc, _Str) ->
     { q(empty_bstr,"<<>>"), 4};
 print_length(<<_/bitstring>>, 1, _RF, _Enc, _Str) ->
-    { lists:join(q(bstr_start,"<<"), 
-		 q(elipsis,"..."),
-		 q(bstr_end,">>")), 7};
+    {[q(bstr_start, "<<"), q(elipsis, "..."), q(bstr_end, ">>")], 7};
 print_length(<<_/bitstring>>=Bin, D, _RF, Enc, Str) ->
     case bit_size(Bin) rem 8 of
         0 ->


### PR DESCRIPTION
Bug reproduction:

```erlang
1> [ <<"lol">> || _ <- lists:seq(1,100) ].
** exception error: undefined function lists:join/3
     in function  k_io_lib_pretty:print_length/5 (src/k_io_lib_pretty.erl, line 397)
     in call from k_io_lib_pretty:print_length_list1/5 (src/k_io_lib_pretty.erl, line 480)
     in call from k_io_lib_pretty:print_length_list1/5 (src/k_io_lib_pretty.erl, line 481)
     in call from k_io_lib_pretty:print_length_list/5 (src/k_io_lib_pretty.erl, line 472)
     in call from k_io_lib_pretty:print/8 (src/k_io_lib_pretty.erl, line 112)
```

After fix:
```erlang
1> [ <<"lol">> || _ <- lists:seq(1,100) ].
[<<"lol">>,<<"lol">>,<<"lol">>,<<"lol">>,<<"lol">>,
 <<"lol">>,<<"lol">>,<<"lol">>,<<"lol">>,<<"lol">>,<<"lol">>,
 <<"lol">>,<<"lol">>,<<"lol">>,<<"lol">>,<<"lol">>,<<"lol">>,
 <<"lol">>,<<"lol">>,<<"lol">>,<<"lol">>,<<"lol">>,<<"lol">>,
 <<"lol">>,<<"lol">>,<<"lol">>,<<"lol">>,<<"lol">>,<<...>>|...]
```
