### PR TITLE
lists:concat/3 not lists:join/3

### DIFF
--- a/src/k_io_lib_pretty.erl
+++ b/src/k_io_lib_pretty.erl
@@ -394,9 +394,7 @@ print_length(Tuple, D, RF, Enc, Str) when is_tuple(Tuple) ->
 print_length(<<>>, _D, _RF, _Enc, _Str) ->
     { q(empty_bstr,"<<>>"), 4};
 print_length(<<_/bitstring>>, 1, _RF, _Enc, _Str) ->
-    { lists:concat(q(bstr_start,"<<"),
-		 q(elipsis,"..."),
-		 q(bstr_end,">>")), 7};
+    { lists:concat([q(bstr_start,"<<"), q(elipsis,"..."), q(bstr_end,">>")]), 7};
 print_length(<<_/bitstring>>=Bin, D, _RF, Enc, Str) ->
     case bit_size(Bin) rem 8 of
         0 ->

--- a/src/k_io_lib_pretty.erl
+++ b/src/k_io_lib_pretty.erl
@@ -394,7 +394,7 @@ print_length(Tuple, D, RF, Enc, Str) when is_tuple(Tuple) ->
 print_length(<<>>, _D, _RF, _Enc, _Str) ->
     { q(empty_bstr,"<<>>"), 4};
 print_length(<<_/bitstring>>, 1, _RF, _Enc, _Str) ->
-    { lists:join(q(bstr_start,"<<"), 
+    { lists:concat(q(bstr_start,"<<"),
 		 q(elipsis,"..."),
 		 q(bstr_end,">>")), 7};
 print_length(<<_/bitstring>>=Bin, D, _RF, Enc, Str) ->


### PR DESCRIPTION
Attempts to truncate a binary in output caused a crash. `lists:join/3` is not a thing.