### PR TITLE
bin/kjell: Bash may not be installed in /bin

### DIFF
--- a/bin/kjell
+++ b/bin/kjell
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 
 SCRIPT_DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/bin/kjell
+++ b/bin/kjell
@@ -3,4 +3,4 @@
 
 SCRIPT_DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 EBIN_DIR="${SCRIPT_DIR}/../ebin"
-erl -noinput -pa ${EBIN_DIR} -run start_kjell $@
+erl -noinput -nouser -pa ${EBIN_DIR} -run start_kjell $@


### PR DESCRIPTION
This happens on OSes such as some *BSD.

Use `/usr/bin/env` to find `bash`, as this is done with many language interpreters.