### PR TITLE
bin/kjell: Bash may not be installed in /bin

### DIFF
--- a/bin/kjell
+++ b/bin/kjell
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 
 SCRIPT_DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
This happens on OSes such as some *BSD.

Use `/usr/bin/env` to find `bash`, as this is done with many language interpreters.